### PR TITLE
Fix flow when using embedded URLs with querystrings inside return URL

### DIFF
--- a/src/IdentityServer/Extensions/StringExtensions.cs
+++ b/src/IdentityServer/Extensions/StringExtensions.cs
@@ -40,6 +40,13 @@ namespace IdentityServer.Extensions
                 : $"{url}?ReturnUrl={Uri.EscapeDataString(Uri.UnescapeDataString(returnUrl))}";
         }
 
+        public static string EncodedReturnUrl(this string url, string returnUrl)
+        {
+            return String.IsNullOrEmpty(returnUrl)
+                ? url
+                : $"{url}?EncodedReturnUrl={Uri.EscapeDataString(Uri.UnescapeDataString(returnUrl.Base64Encode()))}";
+        }
+
         public static string AppendQueryString(this string url, string key, string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -48,6 +55,16 @@ namespace IdentityServer.Extensions
             string item = Uri.EscapeDataString(key) + "=" + Uri.EscapeDataString(Uri.UnescapeDataString(value));
             string prefix = url.Contains('?') ? "&" : "?";
             return url + prefix + item;
+        }
+
+        public static string Base64Encode(this string plainText) {
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
+            return System.Convert.ToBase64String(plainTextBytes);
+        }
+
+        public static string Base64Decode(this string base64EncodedData) {
+           var base64EncodedBytes = System.Convert.FromBase64String(base64EncodedData);
+            return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
         }
 
         public static Claim ToClaim(this string value)

--- a/src/IdentityServer/Features/Account/Account/Code.cs
+++ b/src/IdentityServer/Features/Account/Account/Code.cs
@@ -13,6 +13,7 @@ namespace IdentityServer.Models
         public string Code { get; set; }
         public string Action { get; set; }
         public string ReturnUrl { get; set; }
+        public string EncodedReturnUrl { get; set; }
     }
 
     public class CodeViewModel : CodeModel

--- a/src/IdentityServer/Features/Account/Account/Login.cs
+++ b/src/IdentityServer/Features/Account/Account/Login.cs
@@ -13,6 +13,7 @@ namespace IdentityServer.Models
         public string Password { get; set; }
         public bool RememberLogin { get; set; }
         public string ReturnUrl { get; set; }
+        public string EncodedReturnUrl { get; set; }
         public string Provider { get; set; }
     }
 

--- a/src/IdentityServer/Features/Account/Account/Notice.cs
+++ b/src/IdentityServer/Features/Account/Account/Notice.cs
@@ -6,6 +6,7 @@ namespace IdentityServer.Models
     public class NoticeModel
     {
         public string ReturnUrl { get; set; }
+        public string EncodedReturnUrl { get; set; }
         public string Next { get; set; }
     }
 

--- a/src/IdentityServer/Features/Account/AccountViewService.cs
+++ b/src/IdentityServer/Features/Account/AccountViewService.cs
@@ -118,9 +118,9 @@ namespace IdentityServer.Features.Account
             return vm;
         }
 
-        public async Task<NoticeModel> GetNoticeView(string returnUrl, string next = "Login")
+        public async Task<NoticeModel> GetNoticeView(string returnUrl, string encodedReturnUrl = null, string next = "Login")
         {
-            var model = new NoticeViewModel { ReturnUrl = returnUrl, Next = next};
+            var model = new NoticeViewModel { ReturnUrl = returnUrl, EncodedReturnUrl = encodedReturnUrl, Next = next};
             model.Text = await LoadConfigFile(_options.Authentication.NoticeFile)
                 ?? "This site uses cookies to manage authentication.";
             return model;
@@ -134,10 +134,11 @@ namespace IdentityServer.Features.Account
             return model;
         }
 
-        public CodeViewModel GetCodeView(string returnUrl, CodeState state)
+        public CodeViewModel GetCodeView(string returnUrl, CodeState state, string encodedReturnUrl = null)
         {
             return new CodeViewModel() {
                 ReturnUrl = returnUrl,
+                EncodedReturnUrl = encodedReturnUrl,
                 Token = state?.Token,
             };
         }


### PR DESCRIPTION
Base64Encode Return URL when hitting /account/login.  This is necessary because some return URLs may have embedded URLs with their own query strings, which will get decoded unintentionally when using the "Notice" and/or "2FA" redirection.

For instance, if "Notice" and "2FA" are enabled, the flow becomes:
- /account/login (with returnURL provided)
- /account/notice
- /account/code
- /account/login
- returnURL

When using Redirect(), the URL encoding is lost.  This PR adds an additional encodedReturnURL for the above workflows so that the applications utilizing Identity get a response in the format they expect.  The response style will then also match what already happens if "Notice" and "2FA" are disabled.