### PR TITLE
Improve change password experience with .well-known redirect and new route

### DIFF
--- a/src/IdentityServer/Features/Account/Account/Code.cshtml
+++ b/src/IdentityServer/Features/Account/Account/Code.cshtml
@@ -25,7 +25,7 @@
                     }
 
                     <div class="form-group">
-                        <input class="form-control" type="text" placeholder="Code" style="-webkit-text-security: disc;"
+                        <input class="form-control" type="text" placeholder="Code"
                             aria-label="enter 2fa code" asp-for="Code" autofocus="on" autocomplete="off">
                     </div>
 

--- a/src/IdentityServer/Features/Account/Account/Code.cshtml
+++ b/src/IdentityServer/Features/Account/Account/Code.cshtml
@@ -25,7 +25,7 @@
                     }
 
                     <div class="form-group">
-                        <input class="form-control" type="password" placeholder="Code"
+                        <input class="form-control" type="text" placeholder="Code" style="-webkit-text-security: disc;"
                             aria-label="enter 2fa code" asp-for="Code" autofocus="on" autocomplete="off">
                     </div>
 

--- a/src/IdentityServer/Features/Account/Account/Password.cs
+++ b/src/IdentityServer/Features/Account/Account/Password.cs
@@ -1,0 +1,25 @@
+// Copyright 2020 Carnegie Mellon University.
+// Released under a MIT (SEI) license. See LICENSE.md in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityServer.Models
+{
+    public class PasswordModel
+    {
+        [Required]
+        public string CurrentPassword { get; set; }
+        [Required]
+        public string Password { get; set; }
+        [Required]
+        [Compare("Password", ErrorMessage = "Passwords do not match")]
+        public string ConfirmPassword { get; set; }
+        public string ReturnUrl { get; set; }
+    }
+
+    public class PasswordViewModel : PasswordModel
+    {
+        public string Complexity { get; set; }
+    }
+
+}

--- a/src/IdentityServer/Features/Account/Account/Password.cshtml
+++ b/src/IdentityServer/Features/Account/Account/Password.cshtml
@@ -1,0 +1,34 @@
+@* Copyright 2020 Carnegie Mellon University. *@
+@* Released under a MIT (SEI) license. See LICENSE.md in the project root. *@
+
+@model PasswordViewModel
+<div class="row">
+    <div class="col panel text-center">
+        <h1 class="display-4">Password</h1>
+        <form asp-route="Password">
+            <input type="hidden" asp-for="ReturnUrl" />
+            <fieldset>
+                @await Html.PartialAsync("_ValidationSummary")
+                <div class="form-group">
+                    <input type="password" class="form-control" placeholder="Current Password" required
+                        aria-label="enter current password" asp-for="CurrentPassword" autocomplete="current-password" autofocus="on">
+                </div>
+                <div class="form-group">
+                    <input type="password" class="form-control" placeholder="Password" required
+                        aria-label="enter new password" asp-for="Password" autocomplete="new-password">
+                </div>
+                <div class="form-group">
+                    <input type="password" class="form-control" placeholder="Confirm Password" required
+                        aria-label="confirm new password" asp-for="ConfirmPassword" autocomplete="new-password">
+                </div>
+                <p class="small" aria-label="password complexity requirement">@Model.Complexity</p>
+                <div class="form-group">
+                    <button class="btn btn-primary" name="action"
+                        aria-label="change password" value="reset" type="submit">Submit</button>
+                </div>
+            </fieldset>
+        </form>
+    
+    </div>
+</div>
+

--- a/src/IdentityServer/Features/Account/Account/Password.cshtml
+++ b/src/IdentityServer/Features/Account/Account/Password.cshtml
@@ -14,7 +14,7 @@
                         aria-label="enter current password" asp-for="CurrentPassword" autocomplete="current-password" autofocus="on">
                 </div>
                 <div class="form-group">
-                    <input type="password" class="form-control" placeholder="Password" required
+                    <input type="password" class="form-control" placeholder="New Password" required
                         aria-label="enter new password" asp-for="Password" autocomplete="new-password">
                 </div>
                 <div class="form-group">

--- a/src/IdentityServer/Features/Account/AccountViewService.cs
+++ b/src/IdentityServer/Features/Account/AccountViewService.cs
@@ -58,6 +58,13 @@ namespace IdentityServer.Features.Account
                 ReturnUrl = returnUrl
             });
         }
+        public async Task<PasswordViewModel> GetPasswordView(string returnUrl)
+        {
+            return await GetPasswordView(new PasswordModel
+            {
+                ReturnUrl = returnUrl
+            });
+        }
 
         public async Task<LoginViewModel> GetLoginView(LoginModel model, int lockedSeconds = 0)
         {
@@ -77,6 +84,16 @@ namespace IdentityServer.Features.Account
                 MSIE = IsMSIE(headers[HeaderNames.UserAgent]),
                 CertificateSubject = headers[_options.Authentication.ClientCertSubjectHeader],
                 CertificateIssuer = headers[_options.Authentication.ClientCertIssuerHeader]
+            };
+        }
+        public async Task<PasswordViewModel> GetPasswordView(PasswordModel model, int lockedSeconds = 0)
+        {
+            await Task.Delay(0);
+            return new PasswordViewModel() {
+                CurrentPassword = model.CurrentPassword,
+                Password = model.Password,
+                ConfirmPassword = model.ConfirmPassword,
+                Complexity = _options.Password.ComplexityText
             };
         }
 

--- a/src/IdentityServer/Features/Shared/_Layout.cshtml
+++ b/src/IdentityServer/Features/Shared/_Layout.cshtml
@@ -38,7 +38,7 @@
                         <a class="nav-item nav-link" href="@ViewBag.UiHost/account">Accounts</a>
                     }
                 }
-                <a class="nav-item nav-link pull-right" href="account/logout">Logout</a>
+                <a class="nav-item nav-link pull-right" href="~/account/logout">Logout</a>
             }
         }
     </nav>

--- a/src/IdentityServer/Startup.cs
+++ b/src/IdentityServer/Startup.cs
@@ -270,8 +270,8 @@ namespace IdentityServer
                 });
 
                 options.DefaultPolicy = new AuthorizationPolicyBuilder(
-                    IdentityServer4.IdentityServerConstants.DefaultCookieAuthenticationScheme,
-                    IdentityServer4.IdentityServerConstants.LocalApi.AuthenticationScheme
+                    IdentityServer4.IdentityServerConstants.LocalApi.AuthenticationScheme,
+                    IdentityServer4.IdentityServerConstants.DefaultCookieAuthenticationScheme
                 ).RequireAuthenticatedUser().Build();
             });
 

--- a/src/IdentityServer/Startup.cs
+++ b/src/IdentityServer/Startup.cs
@@ -303,6 +303,8 @@ namespace IdentityServer
                 new RewriteOptions()
                     .AddRewrite(@"^oauth/(.*)", "connect/$1", true)
                     .AddRewrite(@"^api/v4/user", "api/profile/alt", true)
+                    .AddRewrite(@".well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200", ".404", true)
+                    .AddRedirect(@".well-known/change-password", "account/reset")
             );
 
             app.UseStaticFiles();

--- a/src/IdentityServer/Startup.cs
+++ b/src/IdentityServer/Startup.cs
@@ -303,8 +303,7 @@ namespace IdentityServer
                 new RewriteOptions()
                     .AddRewrite(@"^oauth/(.*)", "connect/$1", true)
                     .AddRewrite(@"^api/v4/user", "api/profile/alt", true)
-                    .AddRewrite(@".well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200", ".404", true)
-                    .AddRedirect(@".well-known/change-password", "account/reset")
+                    .AddRedirect(@"^.well-known/change-password", "account/password")
             );
 
             app.UseStaticFiles();
@@ -327,8 +326,6 @@ namespace IdentityServer
                 endpoints.MapJAvatar(_javatar.RoutePrefix).RequireAuthorization();
 
                 endpoints.MapDefaultControllerRoute();
-
-                endpoints.MapFallbackToController("Index", "Home");
             });
         }
 


### PR DESCRIPTION
- added redirect from `.well-known/change-password` to `account/password`
- created new mode, controller, view, and route for change password page
- fixed small bug with logout nav link not being absolute
- added `autofill` attributes to password inputs to meet [standard](https://web.dev/change-password-url/#revisit-your-change-password-page-html) for password managers
- changed 2FA code input from `type="password"` to `style="-webkit-text-security: disc;"` so password managers stopped thinking the one-time code was a password change