### PR TITLE
Add sliding cookie expiration config option to stay signed in when active

### DIFF
--- a/src/IdentityServer/Options/AuthorizationOptions.cs
+++ b/src/IdentityServer/Options/AuthorizationOptions.cs
@@ -8,6 +8,7 @@ namespace IdentityServer.Options
         public string Authority { get; set; }
         public string Audience { get; set; }
         public int CookieLifetimeMinutes { get; set; }
+        public bool CookieSlidingExpiration { get; set; }
         public OAuth2Client SwaggerClient { get; set; }
         public ExternalOidcScheme[] ExternalOidc { get; set; } = new ExternalOidcScheme[]{};
     }

--- a/src/IdentityServer/Options/AuthorizationOptions.cs
+++ b/src/IdentityServer/Options/AuthorizationOptions.cs
@@ -7,7 +7,7 @@ namespace IdentityServer.Options
     {
         public string Authority { get; set; }
         public string Audience { get; set; }
-        public int CookieLifetimeMinutes { get; set; }
+        public int CookieLifetimeMinutes { get; set; } = 600;
         public bool CookieSlidingExpiration { get; set; }
         public OAuth2Client SwaggerClient { get; set; }
         public ExternalOidcScheme[] ExternalOidc { get; set; } = new ExternalOidcScheme[]{};

--- a/src/IdentityServer/Startup.cs
+++ b/src/IdentityServer/Startup.cs
@@ -163,6 +163,7 @@ namespace IdentityServer
                 if (_authOptions.CookieLifetimeMinutes > 0)
                     options.Authentication.CookieLifetime = new TimeSpan(0, _authOptions.CookieLifetimeMinutes, 0);
 
+                options.Authentication.CookieSlidingExpiration = _authOptions.CookieSlidingExpiration;
             })
                 .AddConfiguredSigningCredential(_certificatePath, _certificatePass)
                 .AddClientStore<IdsrvClientStore>()

--- a/src/IdentityServer/appsettings.conf
+++ b/src/IdentityServer/appsettings.conf
@@ -4,9 +4,9 @@
 ## Scroll to bottom for example of appsettings.Development.conf
 ####################
 
-## Set lifetime of identity session cookie
-# Authorization__CookieLifetimeMinutes = 10
-# Authorization__CookieSlidingExpiration = true
+## Set lifetime of identity auth cookie
+# Authorization__CookieLifetimeMinutes = 600
+# Authorization__CookieSlidingExpiration = false
 
 ####################
 ## Database

--- a/src/IdentityServer/appsettings.conf
+++ b/src/IdentityServer/appsettings.conf
@@ -5,7 +5,8 @@
 ####################
 
 ## Set lifetime of identity session cookie
-# Authorization__CookieLifetimeMinutes = 0
+# Authorization__CookieLifetimeMinutes = 10
+# Authorization__CookieSlidingExpiration = true
 
 ####################
 ## Database


### PR DESCRIPTION
Identity Server 4's [Cookie Authentication](https://identityserver4.readthedocs.io/en/latest/topics/signin.html#cookie-authentication) can support a basic cookie setting regarding **sliding** expiration based on ASP.NET Core's [CookieAuthenticationOptions.SlidingExpiration Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.cookies.cookieauthenticationoptions.slidingexpiration?view=aspnetcore-6.0#microsoft-aspnetcore-authentication-cookies-cookieauthenticationoptions-slidingexpiration).

> Set SlidingExpiration to true to instruct the handler to re-issue a new cookie with a new expiration time any time it processes a request which is more than halfway through the expiration window.

This, in addition to OIDC clients using `automaticSilentRenew` or `silentRenewIfActiveSeconds`, should better support the ability to remain logged into an Identity session while active, regardless of a cookie expiring. 

Note that the `Access Token Lifetime` setting for a client in Identity should be *less* than `CookieLifetimeMinutes`. If not, by the time an access token is about to expire and a silent renew is requested, the cookie will have already expired and the silent renew will fail, not allowing a new cookie to be re-issued with sliding behavior. 